### PR TITLE
Refactor to use 3 layers of proofs instead of 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ This system is implemented using Gnark v0.12.0.
 
 ## Architecture
 
-Assuming there are 2 layers, this can be extended to arbitrary layers to preserve O(log n) verification time.
+This can be extended to arbitrary layers to preserve O(log n) verification time.
+
+The explanations assume a 2 layer implementation. 
+
+However, the actual implementation is currently 3 layers, leading to an upper limit of 1 billion accounts. This does not change the guarantees.
 
 ### Bottom layer: 
 

--- a/circuit/circuit_test.go
+++ b/circuit/circuit_test.go
@@ -22,7 +22,7 @@ func TestCircuitWorks(t *testing.T) {
 	assert := test.NewAssert(t)
 
 	var c Circuit
-	goAccounts, goAssetSum, goMerkleRoot, goMerkleRootWithHash := GenerateTestData(count) // Generate test data for 128 accounts
+	goAccounts, goAssetSum, goMerkleRoot, goMerkleRootWithHash := GenerateTestData(count, 0) // Generate test data for 128 accounts
 	c.Accounts = ConvertGoAccountsToAccounts(goAccounts)
 	c.AssetSum = ConvertGoBalanceToBalance(goAssetSum)
 	c.MerkleRoot = goMerkleRoot
@@ -35,7 +35,7 @@ func TestCircuitDoesNotAcceptNegativeAccounts(t *testing.T) {
 	assert := test.NewAssert(t)
 
 	var c Circuit
-	goAccounts, _, _, _ := GenerateTestData(count)
+	goAccounts, _, _, _ := GenerateTestData(count, 0)
 	goAccounts[0].Balance.Bitcoin = *big.NewInt(-1)
 	c.Accounts = ConvertGoAccountsToAccounts(goAccounts)
 	goAssetSum := SumGoAccountBalancesIncludingNegatives(goAccounts)
@@ -51,7 +51,7 @@ func TestCircuitDoesNotAcceptAccountsWithOverflow(t *testing.T) {
 	assert := test.NewAssert(t)
 
 	var c Circuit
-	goAccounts, _, _, _ := GenerateTestData(count)
+	goAccounts, _, _, _ := GenerateTestData(count, 0)
 	amt := make([]byte, 9) // this is 72 bits, overflowing our rangecheck
 	for b := range amt {
 		amt[b] = 0xFF
@@ -71,7 +71,7 @@ func TestCircuitDoesNotAcceptInvalidMerkleRoot(t *testing.T) {
 	assert := test.NewAssert(t)
 
 	var c Circuit
-	goAccounts, goAssetSum, _, goMerkleRootWithHash := GenerateTestData(count) // Generate test data for 128 accounts
+	goAccounts, goAssetSum, _, goMerkleRootWithHash := GenerateTestData(count, 0) // Generate test data for 128 accounts
 	c.Accounts = ConvertGoAccountsToAccounts(goAccounts)
 	c.AssetSum = ConvertGoBalanceToBalance(goAssetSum)
 	c.MerkleRoot = 123
@@ -84,7 +84,7 @@ func TestCircuitDoesNotAcceptInvalidMerkleRootWithSumHash(t *testing.T) {
 	assert := test.NewAssert(t)
 
 	var c Circuit
-	goAccounts, goAssetSum, merkleRoot, _ := GenerateTestData(count) // Generate test data for 128 accounts
+	goAccounts, goAssetSum, merkleRoot, _ := GenerateTestData(count, 0) // Generate test data for 128 accounts
 	c.Accounts = ConvertGoAccountsToAccounts(goAccounts)
 	c.AssetSum = ConvertGoBalanceToBalance(goAssetSum)
 	c.MerkleRoot = merkleRoot

--- a/circuit/utils.go
+++ b/circuit/utils.go
@@ -161,9 +161,10 @@ func SumGoAccountBalances(accounts []GoAccount) GoBalance {
 	return assetSum
 }
 
-func GenerateTestData(count int) (accounts []GoAccount, assetSum GoBalance, merkleRoot []byte, merkleRootWithAssetSumHash []byte) {
+func GenerateTestData(count int, seed int) (accounts []GoAccount, assetSum GoBalance, merkleRoot []byte, merkleRootWithAssetSumHash []byte) {
 	for i := 0; i < count; i++ {
-		btcCount, ethCount := int64(i+45*i+39), int64(i*2+i+1001)
+		iWithSeed := (i + seed) * (seed + 1)
+		btcCount, ethCount := int64(iWithSeed+45*iWithSeed+39), int64(iWithSeed*2+iWithSeed+1001)
 		accounts = append(accounts, GoAccount{UserId: []byte("foo"), Balance: GoBalance{Bitcoin: *big.NewInt(btcCount), Ethereum: *big.NewInt(ethCount)}})
 	}
 	goAccountBalanceSum := SumGoAccountBalances(accounts)

--- a/core/generator.go
+++ b/core/generator.go
@@ -11,7 +11,7 @@ func writeTestDataToFile(batchCount int, countPerBatch int) {
 		filePath := "out/secret/test_data_" + strconv.Itoa(i) + ".json"
 		var secretData ProofElements
 		var assetSum circuit.GoBalance
-		secretData.Accounts, assetSum, secretData.MerkleRoot, secretData.MerkleRootWithAssetSumHash = circuit.GenerateTestData(countPerBatch)
+		secretData.Accounts, assetSum, secretData.MerkleRoot, secretData.MerkleRootWithAssetSumHash = circuit.GenerateTestData(countPerBatch, i+11)
 		secretData.AssetSum = &assetSum
 		err := writeJson(filePath, secretData)
 		if err != nil {
@@ -31,5 +31,5 @@ func writeTestDataToFile(batchCount int, countPerBatch int) {
 }
 
 func GenerateData(batchCount int) {
-	writeTestDataToFile(batchCount, 1024)
+	writeTestDataToFile(batchCount, 16)
 }

--- a/core/utils.go
+++ b/core/utils.go
@@ -83,3 +83,15 @@ func computeAccountLeavesFromAccounts(accounts []circuit.GoAccount) (accountLeav
 	}
 	return accountLeaves
 }
+
+func batchProofs(proofs []CompletedProof, batchSize int) [][]CompletedProof {
+	batches := make([][]CompletedProof, 0)
+	for i := 0; i < len(proofs); i += batchSize {
+		end := i + batchSize
+		if end > len(proofs) {
+			end = len(proofs)
+		}
+		batches = append(batches, proofs[i:end])
+	}
+	return batches
+}


### PR DESCRIPTION
This increases the maximum Go accounts provable from 1 million to 1 billion.